### PR TITLE
fix: update permissions in release-please workflow to allow write access f…

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 name: release-please


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/release-please.yml`. The change modifies the permissions for the `contents` scope from `read` to `write`, enabling the workflow to make changes to repository contents.

* [`.github/workflows/release-please.yml`](diffhunk://#diff-2c84033033d49186c63e6adcd705f63b11ae6814cd76c152c9c486d389fbccf3L8-R8): Updated `contents` permission from `read` to `write` to allow the workflow to modify repository contents.…or contents